### PR TITLE
Problem: Serializer is private

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ use serde::ser;
 use serde_json::Value;
 
 use ast::Ast;
-use variable::Serializer;
+pub use variable::Serializer;
 use interpreter::{interpret, SearchResult};
 
 mod interpreter;


### PR DESCRIPTION
This prevents implementing things like ToJmesPath outside of the crate.

In my particular case, I am trying to implement ToJmesPath that returns a Result for all types (and this also helps avoiding `unwrap` in ToJmesPath)

Solution: make Serializer public