### PR TITLE
Problem: serde_json 1.0.45 breaks jmespath.rs

### DIFF
--- a/src/variable.rs
+++ b/src/variable.rs
@@ -6,7 +6,7 @@ extern crate serde_json;
 use std::vec;
 use serde::{de, ser};
 use serde::de::IntoDeserializer;
-use serde_json::error::{Error, ErrorCode};
+use serde_json::error::Error;
 use serde_json::value::Value;
 use std::collections::BTreeMap;
 use std::cmp::{max, Ordering};
@@ -1202,7 +1202,12 @@ impl ser::SerializeMap for MapState {
     {
         match to_variable(key)? {
             Variable::String(s) => self.next_key = Some(s),
-            _ => return Err(Error::syntax(ErrorCode::KeyMustBeAString, 0, 0)),
+            _ => {
+                // this is an ugly kludge, but error reporting is no longer semi-public in serde_json
+                let mut map = std::collections::HashMap::new();
+                map.insert(true, true);
+                return Err(serde_json::to_vec(&map).unwrap_err())
+            }
         };
         Ok(())
     }


### PR DESCRIPTION
It fails to compile:

```
error[E0603]: enum `ErrorCode` is private
 --> src/variable.rs:9:32
  |
9 | use serde_json::error::{Error, ErrorCode};
  |                                ^^^^^^^^^

error[E0624]: method `syntax` is private
    --> src/variable.rs:1205:29
     |
1205 |             _ => return Err(Error::syntax(ErrorCode::KeyMustBeAString, 0, 0)),
```

This happens because serde_json made `Error::syntax` and `ErrorCode`
available only to `serde_json` itself.

Solution: make serde_json trigger an error we need

It's an ugly kludge but at least it works :) It creates a HashMap with a
non-string key and passes this off to serde_json. It triggers the error
we need.

This is unlikely to be a great solution long term, but at least it makes
jmespath.rs compile without pinning it to 1.0.44 forever.