### PR TITLE
Fix panic on invalid number

### DIFF
--- a/jmespath/src/lib.rs
+++ b/jmespath/src/lib.rs
@@ -508,4 +508,9 @@ mod test {
         let expr = compile("foo").unwrap();
         let _ = expr.clone();
     }
+
+    #[test]
+    fn test_invalid_number() {
+        let _ = compile("6455555524");
+    }
 }


### PR DESCRIPTION
I added a small check for a case that would previous panic.  This was found through fuzzing.  I've found another issue where it is possible to overflow the stack using a query with a long series of ['s.  The change for this might be intrusive though.  Before I fix it I wanted to send this PR up and check to see if you are interested in the more intrusive change.