### PR TITLE
deps: bump libc from 0.2.139 to 0.2.155

### DIFF
--- a/jmespath-cli/Cargo.lock
+++ b/jmespath-cli/Cargo.lock
@@ -92,9 +92,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "ryu"


### PR DESCRIPTION
Add dependencies that support the loongarch64 architecture
https://github.com/rust-lang/libc/pull/2765