### PR TITLE
fix: resolve clippy collapsible_if warnings

### DIFF
--- a/jmespath/src/parser.rs
+++ b/jmespath/src/parser.rs
@@ -83,11 +83,10 @@ impl<'a> Parser<'a> {
         let mut actual_pos = self.offset;
         let mut buff = error_msg.to_string();
         buff.push_str(&format!(" -- found {current_token:?}"));
-        if is_peek {
-            if let Some(&(p, _)) = self.token_queue.front() {
+        if is_peek
+            && let Some(&(p, _)) = self.token_queue.front() {
                 actual_pos = p;
             }
-        }
         JmespathError::new(self.expr, actual_pos, ErrorReason::Parse(buff))
     }
 

--- a/jmespath/src/variable.rs
+++ b/jmespath/src/variable.rs
@@ -348,22 +348,20 @@ impl Variable {
     /// Otherwise, returns Null.
     #[inline]
     pub fn get_field(&self, key: &str) -> Rcvar {
-        if let Variable::Object(map) = self {
-            if let Some(result) = map.get(key) {
+        if let Variable::Object(map) = self
+            && let Some(result) = map.get(key) {
                 return result.clone();
             }
-        }
         Rcvar::new(Variable::Null)
     }
 
     /// If the value is an array, then gets an array value by index. Otherwise returns Null.
     #[inline]
     pub fn get_index(&self, index: usize) -> Rcvar {
-        if let Variable::Array(array) = self {
-            if let Some(result) = array.get(index) {
+        if let Variable::Array(array) = self
+            && let Some(result) = array.get(index) {
                 return result.clone();
             }
-        }
         Rcvar::new(Variable::Null)
     }
 


### PR DESCRIPTION
Collapse nested if statements into single conditional expressions using let chains, as suggested by clippy.

Changes:
- parser.rs: Collapse is_peek check with token_queue.front()
- variable.rs: Collapse Object/Array pattern matches with inner get()

No functional changes - just code style improvements.