### PR TITLE
Make `crate::interpreter::interpret` function part of public API

### DIFF
--- a/jmespath/src/lib.rs
+++ b/jmespath/src/lib.rs
@@ -111,8 +111,7 @@ use std::fmt;
 use std::sync::LazyLock;
 
 use crate::ast::Ast;
-use crate::interpreter::SearchResult;
-pub use crate::interpreter::interpret;
+pub use crate::interpreter::{SearchResult, interpret};
 
 mod errors;
 mod interpreter;


### PR DESCRIPTION
closes #59

Export `crate::interpreter::interpret` function publicly, enabling custom functions to evaluate `expref` arguments

- [X] Existing tests pass