### PR TITLE
 Implement JEP-18 let expression with lexical scoping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Test jmespath
         run: cargo test
 
+      - name: Test jmespath with let-expr feature
+        run: cargo test --features let-expr
+
       - name: Test jmespath with specialized feature (nightly only)
         if: matrix.rust == 'nightly'
         run: cargo +nightly test --features specialized

--- a/jmespath/Cargo.toml
+++ b/jmespath/Cargo.toml
@@ -36,3 +36,7 @@ sync = []
 # however at time of writing it is unstable & so requires a nightly compiler.
 # See https://github.com/rust-lang/rust/issues/31844 for the latest status.
 specialized = []
+# `let-expr` enables JEP-18 lexical scoping with let expressions.
+# Syntax: let $var = expr in body
+# See: https://github.com/jmespath/jmespath.jep/blob/main/proposals/0018-lexical-scope.md
+let-expr = []

--- a/jmespath/src/ast.rs
+++ b/jmespath/src/ast.rs
@@ -168,6 +168,24 @@ pub enum Ast {
         /// Right hand side of the expression.
         rhs: Box<Ast>,
     },
+    #[cfg(feature = "let-expr")]
+    /// Variable reference (JEP-18): $name
+    VariableRef {
+        /// Approximate absolute position in the parsed expression.
+        offset: usize,
+        /// Variable name (without the $ prefix)
+        name: String,
+    },
+    #[cfg(feature = "let-expr")]
+    /// Let expression (JEP-18): let $var = expr, ... in body
+    Let {
+        /// Approximate absolute position in the parsed expression.
+        offset: usize,
+        /// Variable bindings: name -> expression
+        bindings: Vec<(String, Ast)>,
+        /// Body expression to evaluate with bindings in scope
+        expr: Box<Ast>,
+    },
 }
 
 impl fmt::Display for Ast {


### PR DESCRIPTION
This PR implements [JEP-18 (Lexical Scoping)](https://github.com/jmespath/jmespath.jep/blob/main/proposals/0018-lexical-scope.md) as an optional feature. Let expressions allow binding values to variables for use within an expression, enabling queries that reference elements from outer scopes.

## Syntax

```
let $variable = expression in body
let $var1 = expr1, $var2 = expr2 in body
```

## Example

```rust
// Bind a threshold and use it in a filter
let expr = jmespath::compile("let $threshold = `50` in numbers[? @ > $threshold]").unwrap();

// Reference parent data within a nested filter
let expr = jmespath::compile(
    "[*].[let $home_state = home_state in states[? name == $home_state].cities[]][]"
).unwrap();
```

## Features

Per JEP-18 specification:
- `let` and `in` are contextual keywords (not reserved)
- Variable references use `$name` syntax
- Multiple comma-separated bindings supported
- Lexical scoping with inner scope shadowing
- Bindings evaluated in outer scope before body executes
- Projection stopping when bound to variable
- Undefined variable triggers runtime error

Feature-gated behind `let-expr` to maintain backward compatibility:

```toml
[dependencies]
jmespath = { version = "0.5", features = ["let-expr"] }
```

## Changes

- Add `let-expr` feature flag to Cargo.toml
- Add `Variable` and `Assign` tokens to lexer (feature-gated)
- Add `VariableRef` and `Let` AST nodes
- Implement let expression parsing in parser
- Add scope stack to `Context` for variable lookup
- Implement `Let` and `VariableRef` evaluation in interpreter
- Add rustdoc documentation with examples

## Testing

- All 861 compliance tests pass
- 34 unit tests covering:
  - Basic bindings, multiple bindings, nested scopes
  - Variable shadowing and scope restoration
  - Projection stopping behavior
  - Variables in filters, functions, pipes, multiselect
  - Boolean operators (&&, ||, !)
  - Flatten, slice operations
  - Error cases (undefined variable, out of scope, syntax errors)

## Known Limitations

Using `let` or `in` as field names immediately before the `in` keyword (e.g., `let $x = foo.let in ...`) requires more complex parser lookahead. Workaround: use quoted identifiers (`let $x = foo."let" in ...`).